### PR TITLE
Patches to load under ruby 1.8.x

### DIFF
--- a/aerospike.gemspec
+++ b/aerospike.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |s|
   s.post_install_message = "Thank you for using Aerospike!\nYou can report issues on github.com/aerospike/aerospike-client-ruby"
   s.add_dependency("atomic", '~> 1.1')
   s.add_dependency("msgpack", '~> 0.5')
+  s.add_dependency('oniguruma', '~> 1.1.0')
 end

--- a/lib/aerospike.rb
+++ b/lib/aerospike.rb
@@ -11,6 +11,10 @@ class String
   def force_encoding(enc)
     self
   end
+  
+  def ord
+    self[0]
+  end
 end
 
 require 'aerospike/client'

--- a/lib/aerospike.rb
+++ b/lib/aerospike.rb
@@ -7,6 +7,12 @@ require 'resolv'
 require 'msgpack'
 require 'atomic'
 
+class String
+  def force_encoding(enc)
+    self
+  end
+end
+
 require 'aerospike/client'
 require 'aerospike/utils/pool'
 require 'aerospike/utils/epoc'

--- a/lib/aerospike.rb
+++ b/lib/aerospike.rb
@@ -6,6 +6,7 @@ require "timeout"
 require 'resolv'
 require 'msgpack'
 require 'atomic'
+require 'oniguruma'
 
 class String
   def force_encoding(enc)

--- a/lib/aerospike/client.rb
+++ b/lib/aerospike/client.rb
@@ -588,8 +588,7 @@ module Aerospike
         ClientPolicy.new(
           options[:timeout],
           options[:connection_queue_size],
-          options[:fail_if_not_connected],
-        )
+          options[:fail_if_not_connected])
       end
     end
 
@@ -603,8 +602,7 @@ module Aerospike
           options[:priority],
           options[:timeout],
           options[:max_retiries],
-          options[:sleep_between_retries],
-        )
+          options[:sleep_between_retries])
       end
     end
 

--- a/lib/aerospike/cluster/connection.rb
+++ b/lib/aerospike/cluster/connection.rb
@@ -51,7 +51,7 @@ module Aerospike
         begin
           written = @socket.write_nonblock(buffer.read(total, length - total))
           total += written
-        rescue IO::WaitWriteable, Errno::EAGAIN
+        rescue Errno::EAGAIN => e
           IO.select(nil, [@socket])
           retry
         rescue => e
@@ -67,7 +67,7 @@ module Aerospike
           bytes = @socket.recv_nonblock(length - total)
           buffer.write_binary(bytes, total) if bytes.bytesize > 0
           total += bytes.bytesize
-        rescue Errno::EAGAIN
+        rescue Errno::EAGAIN => e
           IO.select([@socket], nil)
           retry
         rescue => e

--- a/lib/aerospike/cluster/connection.rb
+++ b/lib/aerospike/cluster/connection.rb
@@ -67,7 +67,7 @@ module Aerospike
           bytes = @socket.recv_nonblock(length - total)
           buffer.write_binary(bytes, total) if bytes.bytesize > 0
           total += bytes.bytesize
-        rescue IO::WaitReadable,  Errno::EAGAIN
+        rescue Errno::EAGAIN
           IO.select([@socket], nil)
           retry
         rescue => e

--- a/lib/aerospike/cluster/node_validator.rb
+++ b/lib/aerospike/cluster/node_validator.rb
@@ -70,11 +70,11 @@ module Aerospike
     protected
 
     # parses a version string
-    @@version_regexp = Oniguruma::ORegexp.new("(?<v1>\d+)\.(?<v2>\d+)\.(?<v3>\d+).*")
+    @@version_regexp = /(\d+)\.(\d+)\.(\d+).*/
 
     def parse_version_string(version)
       if v = @@version_regexp.match(version)
-        return v['v1'], v['v2'], v['v3']
+        return v[0], v[1], v[2]
       end
 
       raise Aerospike::Exceptions::Parse.new("Invalid build version string in Info: #{version}")

--- a/lib/aerospike/cluster/node_validator.rb
+++ b/lib/aerospike/cluster/node_validator.rb
@@ -70,7 +70,7 @@ module Aerospike
     protected
 
     # parses a version string
-    @@version_regexp = /(?<v1>\d+)\.(?<v2>\d+)\.(?<v3>\d+).*/
+    @@version_regexp = Oniguruma::ORegexp.new("(?<v1>\d+)\.(?<v2>\d+)\.(?<v3>\d+).*")
 
     def parse_version_string(version)
       if v = @@version_regexp.match(version)

--- a/lib/aerospike/loggable.rb
+++ b/lib/aerospike/loggable.rb
@@ -8,7 +8,11 @@ module Aerospike
       if ops.length == 1
         Aerospike.logger.debug([ prefix, ops.first.log_inspect, "runtime: #{runtime}" ].join(' '))
       else
-        first, *middle, last = ops
+
+        first, *tail = ops
+        last = tail[-1]
+        middle = tail[0..-2]
+        
         Aerospike.logger.debug([ prefix, first.log_inspect ].join(' '))
         middle.each { |m| Aerospike.logger.debug([ indent, m.log_inspect ].join(' ')) }
         Aerospike.logger.debug([ indent, last.log_inspect, "runtime: #{runtime}" ].join(' '))

--- a/lib/aerospike/task/index_task.rb
+++ b/lib/aerospike/task/index_task.rb
@@ -24,8 +24,7 @@ module Aerospike
   private
 
   class IndexTask < Task
-
-    MATCHER = /.*load_pct=(?<load_pct>\d+(\.\d+)?).*/
+    MATCHER = Oniguruma::ORegexp.new(".*load_pct=(?<load_pct>\d+(\.\d+)?).*")
 
     def initialize(cluster, namespace, index_name, done=false)
       super(cluster, done)

--- a/lib/aerospike/utils/buffer.rb
+++ b/lib/aerospike/utils/buffer.rb
@@ -82,7 +82,9 @@ module Aerospike
     end
 
     def write_int64(i, offset)
-      @buf[offset, 8] = [i].pack(INT64)
+      #ref: https://plus.google.com/+OriPeleg/posts/P6YX4ETREpf
+      packed = [(i>>32) & 0xffffffff, i & 0xffffffff].pack('NN')
+      @buf[offset, 8] = packed
       8
     end
 
@@ -108,7 +110,7 @@ module Aerospike
 
     def read_int64(offset)
       vals = @buf[offset..offset+7]
-      vals.unpack(INT64)[0]
+      vals.reverse.unpack(INT64)[0]
     end
 
     def read_var_int64(offset, len)
@@ -124,6 +126,10 @@ module Aerospike
       @buf[0..@slice_end-1]
     end
 
+    def inspect
+      to_s
+    end
+    
     def dump(from=nil, to=nil)
       from ||= 0
       to ||= @slice_end - 1

--- a/lib/aerospike/utils/buffer.rb
+++ b/lib/aerospike/utils/buffer.rb
@@ -62,7 +62,7 @@ module Aerospike
     end
 
     def write_byte(byte, offset)
-      @buf.setbyte(offset, byte.ord)
+      @buf[offset] = byte.ord
       1
     end
 
@@ -92,7 +92,7 @@ module Aerospike
       if len
         @buf[start, len]
       else
-        @buf.getbyte(start)
+        @buf[start]
       end
     end
 

--- a/lib/aerospike/utils/buffer.rb
+++ b/lib/aerospike/utils/buffer.rb
@@ -72,12 +72,14 @@ module Aerospike
     end
 
     def write_int16(i, offset)
-      @buf[offset, 2] = [i].pack(INT16)
+      packed = [i].pack(INT16).reverse
+      @buf[offset, 2] = packed #[i].pack(INT16)
       2
     end
 
     def write_int32(i, offset)
-      @buf[offset, 4] = [i].pack(INT32)
+      packed = [i].pack(INT32).reverse
+      @buf[offset, 4] = packed#[i].pack(INT32).reverse
       4
     end
 
@@ -100,12 +102,12 @@ module Aerospike
 
     def read_int16(offset)
       vals = @buf[offset..offset+1]
-      vals.unpack(INT16)[0]
+      vals.reverse.unpack(INT16)[0]
     end
 
     def read_int32(offset)
       vals = @buf[offset..offset+3]
-      vals.unpack(INT32)[0]
+      vals.reverse.unpack(INT32)[0]
     end
 
     def read_int64(offset)

--- a/spec/aerospike/index_spec.rb
+++ b/spec/aerospike/index_spec.rb
@@ -47,12 +47,11 @@ describe Aerospike::Client do
     key = Support.gen_random_key
     client.drop_index(key.namespace,
                       key.set_name,
-                      "index_str_#{key.set_name}",
-                      )
+                      "index_str_#{key.set_name}")
+    
     client.drop_index(key.namespace,
                       key.set_name,
-                      "index_int_#{key.set_name}",
-                      )
+                      "index_int_#{key.set_name}")
 
     client.close
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,7 +9,7 @@ SimpleCov.start
 $:.unshift((Pathname(__FILE__).dirname.parent + 'lib').to_s)
 
 require 'aerospike'
-
+require 'benchmark'
 # Log to a StringIO instance to make sure no exceptions are rasied by our
 # logging code.
 Aerospike.logger = Logger.new(StringIO.new, Logger::DEBUG)


### PR DESCRIPTION
Note: These changes are purely meant for booting the client under ruby 1.8. These changes might break the client under 1.9.

