### PR TITLE
Accept ruby symbol as user_key value. Treat them as text.

### DIFF
--- a/lib/aerospike/value/value.rb
+++ b/lib/aerospike/value/value.rb
@@ -53,6 +53,8 @@ module Aerospike
         end
       when String
         res = StringValue.new(value)
+      when Symbol
+        res = StringValue.new(value.to_s)
       when Value
         res = value
       when Hash
@@ -183,6 +185,10 @@ module Aerospike
 
     def to_s
       @value
+    end
+
+    def to_sym
+      @value.to_sym
     end
 
   end # StringValue

--- a/spec/aerospike/client_spec.rb
+++ b/spec/aerospike/client_spec.rb
@@ -195,11 +195,31 @@ describe Aerospike::Client do
 
       end
 
+      it "should write a key as symbol successfully and get it well, even as text" do
+        key = Support.gen_random_key
+        bin = Aerospike::Bin.new('bin', {
+                                   "string" => nil,
+                                   rand(2**63) => {2 => 11},
+                                   [1, nil, 'this'] => {nil => "nihilism"},
+                                   nil => ["embedded array", 1984, nil, {2 => 'string'}],
+                                   {11 => [11, 'str']} => nil,
+                                   {} => {'array' => ["another string", 17]},
+        })
+        client.put(key, bin)
+
+        expect(client.connected?).to eq true
+
+        record = client.get(key)
+        expect(record.bins['bin']).to eq bin.value
+      end
+
     end
 
-    it "should write a key successfully - and read its header again" do
+    it "should write a key as symbol successfully - and read its header again. It should behave like a String" do
+      key = Support.gen_random_key(key_as_sym: true)
 
-      key = Support.gen_random_key
+      expect(key.user_key.is_a?(String))
+
       client.put(key, Aerospike::Bin.new('bin', 'value'))
 
       expect(client.connected?).to eq true
@@ -208,7 +228,9 @@ describe Aerospike::Client do
       expect(record.bins).to be nil
       expect(record.generation).to eq 1
       expect(record.expiration).to be > 0
+
     end
+
 
   end
 

--- a/spec/support/utils.rb
+++ b/spec/support/utils.rb
@@ -12,8 +12,10 @@ module Support
     RAND_CHARS.shuffle[0,len].join
   end
 
-  def self.gen_random_key(len=50)
-    Aerospike::Key.new('test', 'test', rand_string(len))
+  def self.gen_random_key(len=50, key_as_sym: false)
+    key_val = rand_string(len)
+    key_val = key_val.to_sym if key_as_sym
+    Aerospike::Key.new('test', 'test', key_val)
   end
 
   def self.host


### PR DESCRIPTION
Symbol are first class citizens in Ruby. Ruby dev has the habit to use them as key for hashes. To tell the truth, when I wrote my first AS Key, I put a symbol as user_key and I was surprised AS refused it.
I'm pretty sure I'm not the only one and I think it's a reasonable deal to handle ruby symbol silently as its text counterpart in AS ruby client.