### PR TITLE
Fixed an error when try to instance Statement class

### DIFF
--- a/lib/aerospike.rb
+++ b/lib/aerospike.rb
@@ -82,6 +82,7 @@ require 'aerospike/query/filter'
 require 'aerospike/query/stream_command'
 require 'aerospike/query/query_command'
 require 'aerospike/query/scan_command'
+require 'aerospike/query/statement'
 
 module Aerospike
   extend Loggable


### PR DESCRIPTION
I have a module that include `Aerospike`. I have another class that include the first module and try to instance `Aerospike` classes like `Client` and `Statement`. `Client` class is instanced, but when I try to instance `Statement` I get this error:

```
NameError: uninitialized constant Statement
	from /opt/rb/var/www/rb-rails/lib/<route to rb>.rb:41:in `query'
	from (irb):2
	from /usr/local/rvm/gems/ruby-2.1.2/gems/railties-4.0.12/lib/rails/commands/console.rb:90:in `start'
	from /usr/local/rvm/gems/ruby-2.1.2/gems/railties-4.0.12/lib/rails/commands/console.rb:9:in `start'
	from /usr/local/rvm/gems/ruby-2.1.2/gems/railties-4.0.12/lib/rails/commands.rb:62:in `<top (required)>'
	from bin/rails:4:in `require'
	from bin/rails:4:in `<main>'
```

To solve this error I require `Statement` class on `aerospike.rb` and It works fine.