### PR TITLE
Added `to_s`method to filters

### DIFF
--- a/lib/aerospike/query/filter.rb
+++ b/lib/aerospike/query/filter.rb
@@ -53,6 +53,14 @@ module Aerospike
       offset
     end
 
+    #
+    # Show the filter as String. This is util to show filters in logs.
+    #
+    def to_s
+      return "#{@name} = #{@begin}" if @begin == @end
+      "#{@name} = #{@begin} - #{@end}"
+    end
+
     private
 
     def initialize(bin_name, begin_value, end_value)


### PR DESCRIPTION
This method can be used to log query information. It's useful to log full queries (like ActiveRecord) when you are debugging a Rails app.