### PR TITLE
Disable/enable tend info

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ To read about performance variables, please refer to [`docs/performance.md`](doc
 Aerospike show `INFO` messages on log with information about the status of the cluster. If you need to disable this messages, create a initializer file and set `tend_info`config variable to false. For example, if you are using Rails, you can create file on `config/initializers/aerospike.rb` and set this content:
 
 ```ruby
-# Initialize material icons setup
+# Initialize Aerospike setup
 Aerospike.setup do |config|
   # This will disable tend logs
   config.tend_info = false

--- a/README.md
+++ b/README.md
@@ -90,6 +90,19 @@ We are bending all efforts to improve the client's performance. In out reference
 
 To read about performance variables, please refer to [`docs/performance.md`](docs/performance.md)
 
+<a name="Log"></a>
+## Log
+
+Aerospike show `INFO` messages on log with information about the status of the cluster. If you need to disable this messages, create a initializer file and set `tend_info`config variable to false. For example, if you are using Rails, you can create file on `config/initializers/aerospike.rb` and set this content:
+
+```ruby
+# Initialize material icons setup
+Aerospike.setup do |config|
+  # This will disable tend logs
+  config.tend_info = false
+end
+```
+
 <a name="Tests"></a>
 ## Tests
 

--- a/lib/aerospike.rb
+++ b/lib/aerospike.rb
@@ -86,4 +86,36 @@ require 'aerospike/query/statement'
 
 module Aerospike
   extend Loggable
+
+  # Show Tend info in logger
+  @@tend_info = true
+
+  #
+  # Return the value of tend_info
+  #
+  # == Returns:
+  # Booleand indicating if tend_info must be showed
+  #
+  def self.tend_info
+    @@tend_info
+  end
+
+  #
+  # Set the value for tend_info
+  #
+  # == Parameters:
+  # tend::
+  #   Boolean to enable or disable tend_info logger
+  #
+  def self.tend_info=(tend)
+    @@tend_info = tend
+  end
+
+  #
+  # Initialize the config of Aerospike Ruby gem. Available config:
+  #   - tend_info
+  #
+  def self.setup
+    yield self
+  end
 end

--- a/lib/aerospike/cluster/cluster.rb
+++ b/lib/aerospike/cluster/cluster.rb
@@ -238,6 +238,9 @@ module Aerospike
       remove_list = find_nodes_to_remove(refresh_count)
       remove_nodes(remove_list) unless remove_list.empty?
 
+      # Guard clause to prevent show tend_info because is disabled by config.
+      # See documentation
+      return unless Aerospike.tend_info
       Aerospike.logger.info("Tend finished. Live node count: #{nodes.length}")
     end
 


### PR DESCRIPTION
Develop a solution to https://github.com/aerospike/aerospike-client-ruby/issues/20. Now you can enable or disable Tend Info in Aerospike gem. It's enabled by default.