### PR TITLE
Fix record initialization issue

### DIFF
--- a/lib/aerospike/command/read_command.rb
+++ b/lib/aerospike/command/read_command.rb
@@ -92,8 +92,7 @@ module Aerospike
       end
 
       if op_count == 0
-        # data Bin was not returned.
-        @record = Record.new(@node, @key, generation, expiration)
+        @record = Record.new(@node, @key, nil, generation, expiration)
         return
       end
 

--- a/spec/aerospike/client_spec.rb
+++ b/spec/aerospike/client_spec.rb
@@ -350,6 +350,14 @@ describe Aerospike::Client do
       Aerospike::Bin.new('bin name', rand(456123890))
     end
 
+    it "should #add, #get" do
+      client.operate(key, [
+                       Aerospike::Operation.add(bin_int),
+      ])
+      rec = client.get(key)
+      expect(rec.bins[bin_str.name]).to eq bin_int.value * 1
+      expect(rec.generation).to eq 1
+    end
 
     it "should #put, #append" do
 


### PR DESCRIPTION
Ran into a syntax error when performing increment batch operations on empty records.

Included is a test that was failing on the old code path. Note that the broken code path is only triggered when performing a single add batch operation; performing an add + get batch operation does not trigger this path.