### PR TITLE
fail_if_not_connected param for ClientPolicy

### DIFF
--- a/lib/aerospike/policy/client_policy.rb
+++ b/lib/aerospike/policy/client_policy.rb
@@ -30,7 +30,7 @@ module Aerospike
       @connection_queue_size = opt[:connection_queue_size] || 64
 
       # Throw exception if host connection fails during add_host.
-      @fail_if_not_connected = opt[:fail_if_not_connected] || true
+      @fail_if_not_connected = opt.has_key?(:fail_if_not_connected) ? opt[:fail_if_not_connected] : true
 
       # user name
       @user = opt[:user]

--- a/spec/aerospike/policy/client_policy_spec.rb
+++ b/spec/aerospike/policy/client_policy_spec.rb
@@ -27,8 +27,8 @@ describe Aerospike::ClientPolicy do
       policy = described_class.new
 
       expect(policy.class).to eq described_class
-      expect(policy.timeout).to be 1.0
-      expect(policy.connection_queue_size).to be 64
+      expect(policy.timeout).to eq 1.0
+      expect(policy.connection_queue_size).to eq 64
       expect(policy.fail_if_not_connected).to be_true
       expect(policy.user).to be_nil
       expect(policy.password).to be_nil

--- a/spec/aerospike/policy/client_policy_spec.rb
+++ b/spec/aerospike/policy/client_policy_spec.rb
@@ -1,0 +1,45 @@
+# encoding: utf-8
+# Copyright 2015 Aerospike, Inc.
+#
+# Portions may be licensed to Aerospike, Inc. under one or more contributor
+# license agreements.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+require "spec_helper"
+
+require "aerospike/policy/client_policy"
+
+describe Aerospike::ClientPolicy do
+
+  describe "#initialize" do
+
+    it "should make a client policy with default values" do
+
+      policy = described_class.new
+
+      expect(policy.class).to eq described_class
+      expect(policy.timeout).to be 1.0
+      expect(policy.connection_queue_size).to be 64
+      expect(policy.fail_if_not_connected).to be_true
+      expect(policy.user).to be_nil
+      expect(policy.password).to be_nil
+    end
+
+    it "should make a client policy with fail_if_not_connected set to false" do
+
+      policy = described_class.new(fail_if_not_connected: false)
+
+      expect(policy.fail_if_not_connected).to be_false
+    end
+  end
+
+end


### PR DESCRIPTION
Fix client policy to actually accept fail_if_not_connected parameter from constructor opts.