### PR TITLE
Fix raise of Aerospike::Exceptions::Parse in Client#hash_to_bin

### DIFF
--- a/lib/aerospike/client.rb
+++ b/lib/aerospike/client.rb
@@ -841,7 +841,7 @@ module Aerospike
         hash # it is a list of bins
       else
         hash.map do |k, v|
-          raise Aerospike::Exceptions::Parse("bin name `#{k}` is not a string.") unless k.is_a?(String)
+          raise Aerospike::Exceptions::Parse.new("bin name `#{k}` is not a string.") unless k.is_a?(String)
           Bin.new(k, v)
         end
       end


### PR DESCRIPTION
Hi,

Client#hash_to_bin raises ``NoMethodError: undefined method `Parse' for Aerospike::Exceptions:Module`` when the keys in the map are not strings instead of the intended `Aerospike::Exceptions::Parse`.

This fix properly initializes `Aerospike::Exceptions::Parse`.