### PR TITLE
Convert Integer User Keys To Big Endian Unsigned 64 Bits

### DIFF
--- a/lib/aerospike/value/value.rb
+++ b/lib/aerospike/value/value.rb
@@ -230,7 +230,9 @@ module Aerospike
     end
 
     def to_bytes
-      [@value].pack('Q<')
+      # Convert integer to big endian unsigned 64 bits.
+      # @see http://ruby-doc.org/core-2.3.0/Array.html#method-i-pack
+      [@value].pack('Q>')
     end
 
     def to_s

--- a/spec/aerospike/key_spec.rb
+++ b/spec/aerospike/key_spec.rb
@@ -32,4 +32,20 @@ describe Aerospike::Key do
 
   end # describe
 
+  describe '#digest' do
+
+    context 'with an integer user key' do
+
+      it 'computes a correct digest' do
+
+        k = described_class.new('namespace', 'set', 42)
+
+        expect(k.digest.unpack('H*')).to eq ['386f89f493f3fd7ec333d43dd4dec8aa2e7d6ccf']
+
+      end
+
+    end # context
+
+  end # describe
+
 end # describe


### PR DESCRIPTION
Integer keys written with the Ruby client could not be read from other clients, because the digest was encoded with little endian and not with big endian like the other clients do.

BigEndian usage in other clients:
* Java client: https://github.com/aerospike/aerospike-client-java/blob/master/client/src/com/aerospike/client/command/Buffer.java#L421-L434
* Go client: https://github.com/aerospike/aerospike-client-go/blob/aefd17d20eb8d003926a5d322aeb6976a313a558/utils/buffer/buffer.go#L113-L122

credit goes to @mohamagdy