### PR TITLE
Fix a typo in the "max_retries" policy parameter name

### DIFF
--- a/lib/aerospike/policy/policy.rb
+++ b/lib/aerospike/policy/policy.rb
@@ -47,7 +47,7 @@ module Aerospike
       # A retry is attempted when there is a network error other than timeout.
       # If max_retries is exceeded, the abort will occur even if the timeout
       # has not yet been exceeded.
-      @max_retries = opt[:max_retiries] || 2
+      @max_retries = opt[:max_retries] || 2
 
       # Duration to sleep between retries if a transaction fails and the
       # timeout was not exceeded. Enter zero to skip sleep.

--- a/spec/aerospike/policy/policy_spec.rb
+++ b/spec/aerospike/policy/policy_spec.rb
@@ -35,4 +35,16 @@ describe Aerospike::Policy do
     end
   end
 
+  describe "#max_retries" do
+
+    it "should return custom policy option" do
+
+      policy = described_class.new(max_retries: 42)
+
+      expect(policy.max_retries).to eq 42
+
+    end
+
+  end
+
 end


### PR DESCRIPTION
`max_retiries` => `max_retries`