### PR TITLE
Fix typo handling exception when validating cluster's nodes

### DIFF
--- a/lib/aerospike/cluster/cluster.rb
+++ b/lib/aerospike/cluster/cluster.rb
@@ -381,7 +381,7 @@ module Aerospike
           else
             begin
               nv = NodeValidator.new(self, aliass, @connection_timeout, @cluster_name)
-            rescue Exection => e
+            rescue => e
               Aerospike.logger.error("Seed #{seed.to_s} failed: #{e}")
               next
             end


### PR DESCRIPTION
It was typed `Exection` instead of `Exception`