### PR TITLE
Update test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rvm:
 - 2.3
 - 2.4
 - ruby-head
-- rbx
+- rbx-2
 env: CI="travis"
 sudo: false
 os:
@@ -16,7 +16,7 @@ dist: trusty
 matrix:
   allow_failures:
   - rvm: ruby-head
-  - rvm: rbx
+  - rvm: rbx-2
   fast_finish: true
 install:
 - wget -O aerospike-server.tgz http://aerospike.com/download/server/latest/artifact/tgz

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ language: ruby
 cache: bundler
 bundler_args: --without development
 rvm:
-- 2.0
 - 2.1
-- 2.2.1
-- 2.3.1
+- 2.2
+- 2.3
+- 2.4
 - ruby-head
 - rbx
 env: CI="travis"

--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@
 
 An Aerospike library for Ruby.
 
-This library is compatible with Ruby 2.0+ and supports Linux, Mac OS X and various other BSDs. Rubinius is supported, but not JRuby - yet.
-
+This library is compatible with Ruby 2.1+ and supports Linux, Mac OS X and various other BSDs. Rubinius is supported, but not JRuby.
 
 - [Usage](#Usage)
 - [Prerequisites](#Prerequisites)


### PR DESCRIPTION
Official support for Ruby 2.0 by the Ruby Core team ended in Feb 2016.
Official support for Ruby 2.1 by the Ruby Core team ended in Apr 2017.

Though there haven't been any changes in the client that would prevent
it from running on these old Ruby versions, I am removing Ruby 2.0 from
the test matrix. Future releases of the client _might_ break
compatibility with Ruby 2.0 though not intentionally.

As official support for Ruby 2.1 has just ended we should continue to
support it in the client for some more time.