### PR TITLE
Avoid easy allocations

### DIFF
--- a/lib/aerospike/client.rb
+++ b/lib/aerospike/client.rb
@@ -289,7 +289,7 @@ module Aerospike
 
     #  Read record header and bins for specified key.
     #  The policy can be used to specify timeouts.
-    def get(key, bin_names=[], options = nil)
+    def get(key, bin_names = nil, options = nil)
       policy = create_policy(options, Policy)
 
       command = ReadCommand.new(@cluster, policy, key, bin_names)
@@ -314,7 +314,7 @@ module Aerospike
     #  The returned records are in positional order with the original key array order.
     #  If a key is not found, the positional record will be nil.
     #  The policy can be used to specify timeouts.
-    def batch_get(keys, bin_names=[], options = nil)
+    def batch_get(keys, bin_names = nil, options = nil)
       policy = create_policy(options, Policy)
 
       # wait until all migrations are finished
@@ -596,7 +596,7 @@ module Aerospike
     # Scan Operations
     #-------------------------------------------------------
 
-    def scan_all(namespace, set_name, bin_names=[], options = nil)
+    def scan_all(namespace, set_name, bin_names = nil, options = nil)
       policy = create_policy(options, ScanPolicy)
 
       # wait until all migrations are finished
@@ -652,7 +652,7 @@ module Aerospike
 
     # ScanNode reads all records in specified namespace and set, from one node only.
     # The policy can be used to specify timeouts.
-    def scan_node(node, namespace, set_name, bin_names=[], options = nil)
+    def scan_node(node, namespace, set_name, bin_names = nil, options = nil)
       policy = create_policy(options, ScanPolicy)
       # wait until all migrations are finished
       # TODO: implement

--- a/lib/aerospike/client.rb
+++ b/lib/aerospike/client.rb
@@ -328,7 +328,7 @@ module Aerospike
       key_map = BatchItem.generate_map(keys)
 
       batch_execute(keys) do |node, bns|
-        BatchCommandGet.new(node, bns, policy, key_map, bin_names.uniq, records, INFO1_READ)
+        BatchCommandGet.new(node, bns, policy, key_map, bin_names, records, INFO1_READ)
       end
       records
     end

--- a/lib/aerospike/client.rb
+++ b/lib/aerospike/client.rb
@@ -110,7 +110,7 @@ module Aerospike
     #
     #  client.put key, {'bin', 'value string'}, :timeout => 0.001
 
-    def put(key, bins, options={})
+    def put(key, bins, options = nil)
       policy = create_policy(options, WritePolicy)
       command = WriteCommand.new(@cluster, policy, key, hash_to_bins(bins), Aerospike::Operation::WRITE)
       execute_command(command)
@@ -133,7 +133,7 @@ module Aerospike
     #
     #  client.append key, {'bin', 'value to append'}, :timeout => 0.001
 
-    def append(key, bins, options={})
+    def append(key, bins, options = nil)
       policy = create_policy(options, WritePolicy)
       command = WriteCommand.new(@cluster, policy, key, hash_to_bins(bins), Aerospike::Operation::APPEND)
       execute_command(command)
@@ -152,7 +152,7 @@ module Aerospike
     #
     #  client.prepend key, {'bin', 'value to prepend'}, :timeout => 0.001
 
-    def prepend(key, bins, options={})
+    def prepend(key, bins, options = nil)
       policy = create_policy(options, WritePolicy)
       command = WriteCommand.new(@cluster, policy, key, hash_to_bins(bins), Aerospike::Operation::PREPEND)
       execute_command(command)
@@ -175,7 +175,7 @@ module Aerospike
     #
     #  client.add key, {'bin', -1}, :timeout => 0.001
 
-    def add(key, bins, options={})
+    def add(key, bins, options = nil)
       policy = create_policy(options, WritePolicy)
       command = WriteCommand.new(@cluster, policy, key, hash_to_bins(bins), Aerospike::Operation::ADD)
       execute_command(command)
@@ -197,7 +197,7 @@ module Aerospike
     #
     #  existed = client.delete key, :timeout => 0.001
 
-    def delete(key, options={})
+    def delete(key, options = nil)
       policy = create_policy(options, WritePolicy)
       command = DeleteCommand.new(@cluster, policy, key)
       execute_command(command)
@@ -245,7 +245,7 @@ module Aerospike
     #
     #  client.touch key, :timeout => 0.001
 
-    def touch(key, options={})
+    def touch(key, options = nil)
       policy = create_policy(options, WritePolicy)
       command = TouchCommand.new(@cluster, policy, key)
       execute_command(command)
@@ -258,7 +258,7 @@ module Aerospike
     ##
     #  Determines if a record key exists.
     #  The policy can be used to specify timeouts.
-    def exists(key, options={})
+    def exists(key, options = nil)
       policy = create_policy(options, Policy)
       command = ExistsCommand.new(@cluster, policy, key)
       execute_command(command)
@@ -268,7 +268,7 @@ module Aerospike
     #  Check if multiple record keys exist in one batch call.
     #  The returned array bool is in positional order with the original key array order.
     #  The policy can be used to specify timeouts.
-    def batch_exists(keys, options={})
+    def batch_exists(keys, options = nil)
       policy = create_policy(options, Policy)
 
       # same array can be used without sychronization;
@@ -289,7 +289,7 @@ module Aerospike
 
     #  Read record header and bins for specified key.
     #  The policy can be used to specify timeouts.
-    def get(key, bin_names=[], options={})
+    def get(key, bin_names=[], options = nil)
       policy = create_policy(options, Policy)
 
       command = ReadCommand.new(@cluster, policy, key, bin_names)
@@ -299,7 +299,7 @@ module Aerospike
 
     #  Read record generation and expiration only for specified key.  Bins are not read.
     #  The policy can be used to specify timeouts.
-    def get_header(key, options={})
+    def get_header(key, options = nil)
       policy = create_policy(options, Policy)
       command = ReadHeaderCommand.new(@cluster, policy, key)
       execute_command(command)
@@ -314,7 +314,7 @@ module Aerospike
     #  The returned records are in positional order with the original key array order.
     #  If a key is not found, the positional record will be nil.
     #  The policy can be used to specify timeouts.
-    def batch_get(keys, bin_names=[], options={})
+    def batch_get(keys, bin_names=[], options = nil)
       policy = create_policy(options, Policy)
 
       # wait until all migrations are finished
@@ -337,7 +337,7 @@ module Aerospike
     #  The returned records are in positional order with the original key array order.
     #  If a key is not found, the positional record will be nil.
     #  The policy can be used to specify timeouts.
-    def batch_get_header(keys, options={})
+    def batch_get_header(keys, options = nil)
       policy = create_policy(options, Policy)
 
       # wait until all migrations are finished
@@ -365,7 +365,7 @@ module Aerospike
     #  An example would be to add an integer value to an existing record and then
     #  read the result, all in one database call. Operations are executed in
     #  the order they are specified.
-    def operate(key, operations, options={})
+    def operate(key, operations, options = nil)
       policy = create_policy(options, WritePolicy)
 
       command = OperateCommand.new(@cluster, policy, key, operations)
@@ -383,7 +383,7 @@ module Aerospike
     #  RegisterTask instance.
     #
     #  This method is only supported by Aerospike 3 servers.
-    def register_udf_from_file(client_path, server_path, language, options={})
+    def register_udf_from_file(client_path, server_path, language, options = nil)
       udf_body = File.read(client_path)
       register_udf(udf_body, server_path, language, options)
     end
@@ -394,7 +394,7 @@ module Aerospike
     #  RegisterTask instance.
     #
     #  This method is only supported by Aerospike 3 servers.
-    def register_udf(udf_body, server_path, language, options={})
+    def register_udf(udf_body, server_path, language, options = nil)
       content = Base64.strict_encode64(udf_body).force_encoding('binary')
 
       str_cmd = "udf-put:filename=#{server_path};content=#{content};"
@@ -424,7 +424,7 @@ module Aerospike
     #  RemoveTask instance.
     #
     #  This method is only supported by Aerospike 3 servers.
-    def remove_udf(udf_name, options={})
+    def remove_udf(udf_name, options = nil)
       str_cmd = "udf-remove:filename=#{udf_name};"
 
       # Send command to one node. That node will distribute it to other nodes.
@@ -441,7 +441,7 @@ module Aerospike
 
     #  ListUDF lists all packages containing user defined functions in the server.
     #  This method is only supported by Aerospike 3 servers.
-    def list_udf(options={})
+    def list_udf(options = nil)
       str_cmd = 'udf-list'
 
       # Send command to one node. That node will distribute it to other nodes.
@@ -477,7 +477,7 @@ module Aerospike
     #  udf file = <server udf dir>/<package name>.lua
     #
     #  This method is only supported by Aerospike 3 servers.
-    def execute_udf(key, package_name, function_name, args=[], options={})
+    def execute_udf(key, package_name, function_name, args=[], options = nil)
       policy = create_policy(options, WritePolicy)
 
       command = ExecuteCommand.new(@cluster, policy, key, package_name, function_name, args)
@@ -506,7 +506,7 @@ module Aerospike
     #
     # This method is only supported by Aerospike 3 servers.
     # If the policy is nil, the default relevant policy will be used.
-    def execute_udf_on_query(statement, package_name, function_name, function_args=[], options={})
+    def execute_udf_on_query(statement, package_name, function_name, function_args=[], options = nil)
       policy = create_policy(options, QueryPolicy)
 
       nodes = @cluster.nodes
@@ -543,7 +543,7 @@ module Aerospike
     #  This method is only supported by Aerospike 3 servers.
     #  index_type should be :string, :numeric or :geo2dsphere (requires server version 3.7 or later)
     #  collection_type should be :list, :mapkeys or :mapvalues
-    def create_index(namespace, set_name, index_name, bin_name, index_type, collection_type=nil, options={})
+    def create_index(namespace, set_name, index_name, bin_name, index_type, collection_type=nil, options = nil)
       if options.nil? && collection_type.is_a?(Hash)
         options, collection_type = collection_type, nil
       end
@@ -572,7 +572,7 @@ module Aerospike
 
     #  Delete secondary index.
     #  This method is only supported by Aerospike 3 servers.
-    def drop_index(namespace, set_name, index_name, options={})
+    def drop_index(namespace, set_name, index_name, options = nil)
       policy = create_policy(options, WritePolicy)
       str_cmd = "sindex-delete:ns=#{namespace}"
       str_cmd << ";set=#{set_name}" unless set_name.to_s.strip.empty?
@@ -596,7 +596,7 @@ module Aerospike
     # Scan Operations
     #-------------------------------------------------------
 
-    def scan_all(namespace, set_name, bin_names=[], options={})
+    def scan_all(namespace, set_name, bin_names=[], options = nil)
       policy = create_policy(options, ScanPolicy)
 
       # wait until all migrations are finished
@@ -652,7 +652,7 @@ module Aerospike
 
     # ScanNode reads all records in specified namespace and set, from one node only.
     # The policy can be used to specify timeouts.
-    def scan_node(node, namespace, set_name, bin_names=[], options={})
+    def scan_node(node, namespace, set_name, bin_names=[], options = nil)
       policy = create_policy(options, ScanPolicy)
       # wait until all migrations are finished
       # TODO: implement
@@ -694,7 +694,7 @@ module Aerospike
     #
     # This method is only supported by Aerospike 3 servers.
     # If the policy is nil, a default policy will be generated.
-    def query(statement, options={})
+    def query(statement, options = nil)
       policy = create_policy(options, QueryPolicy)
       new_policy = policy.clone
 
@@ -730,7 +730,7 @@ module Aerospike
 
     # Create user with password and roles. Clear-text password will be hashed using bcrypt
     # before sending to server.
-    def create_user(user, password, roles, options={})
+    def create_user(user, password, roles, options = nil)
       policy = create_policy(options, AdminPolicy)
       hash = AdminCommand.hash_password(password)
       command = AdminCommand.new
@@ -738,14 +738,14 @@ module Aerospike
     end
 
     # Remove user from cluster.
-    def drop_user(user, options={})
+    def drop_user(user, options = nil)
       policy = create_policy(options, AdminPolicy)
       command = AdminCommand.new
       command.drop_user(@cluster, policy, user)
     end
 
     # Change user's password. Clear-text password will be hashed using bcrypt before sending to server.
-    def change_password(user, password, options={})
+    def change_password(user, password, options = nil)
       raise Aerospike::Exceptions::Aerospike.new(INVALID_USER) unless @cluster.user && @cluster.user != ""
       policy = create_policy(options, AdminPolicy)
 
@@ -764,28 +764,28 @@ module Aerospike
     end
 
     # Add roles to user's list of roles.
-    def grant_roles(user, roles, options={})
+    def grant_roles(user, roles, options = nil)
       policy = create_policy(options, AdminPolicy)
       command = AdminCommand.new
       command.grant_roles(@cluster, policy, user, roles)
     end
 
     # Remove roles from user's list of roles.
-    def revoke_roles(user, roles, options={})
+    def revoke_roles(user, roles, options = nil)
       policy = create_policy(options, AdminPolicy)
       command = AdminCommand.new
       command.revoke_roles(@cluster, policy, user, roles)
     end
 
     # Retrieve roles for a given user.
-    def query_user(user, options={})
+    def query_user(user, options = nil)
       policy = create_policy(options, AdminPolicy)
       command = AdminCommand.new
       command.query_user(@cluster, policy, user)
     end
 
     # Retrieve all users and their roles.
-    def query_users(options={})
+    def query_users(options = nil)
       policy = create_policy(options, AdminPolicy)
       command = AdminCommand.new
       command.query_users(@cluster, policy)

--- a/lib/aerospike/cluster/partition.rb
+++ b/lib/aerospike/cluster/partition.rb
@@ -1,4 +1,5 @@
-# encoding: utf-8
+# frozen_string_literal: true
+
 # Copyright 2014-2017 Aerospike, Inc.
 #
 # Portions may be licensed to Aerospike, Inc. under one or more contributor
@@ -19,6 +20,8 @@ module Aerospike
   private
 
   class Partition # :nodoc:
+    UNPACK_FORMAT = 'l<'
+
     attr_reader :namespace, :partition_id
 
     def initialize(namespace, partition_id)
@@ -31,7 +34,7 @@ module Aerospike
     def self.new_by_key(key)
       Partition.new(
         key.namespace,
-        (key.digest[0..3].unpack('l<')[0] & 0xFFFF) % Node::PARTITIONS
+        (key.digest[0..3].unpack(UNPACK_FORMAT)[0] & 0xFFFF) % Node::PARTITIONS
       )
     end
 

--- a/lib/aerospike/command/read_command.rb
+++ b/lib/aerospike/command/read_command.rb
@@ -1,4 +1,5 @@
-# encoding: utf-8
+# frozen_string_literal: true
+
 # Copyright 2014-2017 Aerospike, Inc.
 #
 # Portions may be licensed to Aerospike, Inc. under one or more contributor
@@ -25,6 +26,8 @@ module Aerospike
   private
 
   class ReadCommand < SingleCommand #:nodoc:
+    VALUE_ENCODING = 'utf-8'
+
 
     attr_reader :record, :policy
 
@@ -127,7 +130,7 @@ module Aerospike
         op_size = @data_buffer.read_int32(receive_offset)
         particle_type = @data_buffer.read(receive_offset+5).ord
         name_size = @data_buffer.read(receive_offset+7).ord
-        name = @data_buffer.read(receive_offset+8, name_size).force_encoding('utf-8')
+        name = @data_buffer.read(receive_offset+8, name_size).force_encoding(VALUE_ENCODING)
         receive_offset += 4 + 4 + name_size
 
         particle_bytes_size = op_size - (4 + name_size)

--- a/lib/aerospike/command/read_command.rb
+++ b/lib/aerospike/command/read_command.rb
@@ -26,8 +26,7 @@ module Aerospike
   private
 
   class ReadCommand < SingleCommand #:nodoc:
-    VALUE_ENCODING = 'utf-8'
-
+    BIN_NAME_ENCODING = 'utf-8'
 
     attr_reader :record, :policy
 
@@ -130,7 +129,7 @@ module Aerospike
         op_size = @data_buffer.read_int32(receive_offset)
         particle_type = @data_buffer.read(receive_offset+5).ord
         name_size = @data_buffer.read(receive_offset+7).ord
-        name = @data_buffer.read(receive_offset+8, name_size).force_encoding(VALUE_ENCODING)
+        name = @data_buffer.read(receive_offset+8, name_size).force_encoding(BIN_NAME_ENCODING)
         receive_offset += 4 + 4 + name_size
 
         particle_bytes_size = op_size - (4 + name_size)


### PR DESCRIPTION
Micro-optimizations. Not a huge performance improvement but low hanging fruits for getting rid of allocations during common operations

These are avoided when running 10k put + 10k get
```
aerospike/client.rb:115   T_HASH   10000
aerospike/client.rb:294   T_HASH   10000
aerospike/client.rb:292  T_ARRAY   10000
aerospike/command/read_command.rb:130 T_STRING   10000
aerospike/cluster/partition.rb:34 T_STRING   40000
```