### PR TITLE
JRuby support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
 - 2.4
 - 2.3
 - rbx-3
+- jruby
 env:
   global:
     - AEROSPIKE_HOSTS=127.0.0.1:3000,127.0.0.1:3100
@@ -17,6 +18,7 @@ dist: trusty
 matrix:
   allow_failures:
   - rvm: rbx-3
+  - rvm: jruby
   fast_finish: true
 before_script:
 - .travis/start_cluster.sh 2

--- a/Gemfile
+++ b/Gemfile
@@ -11,15 +11,14 @@ end
 
 gem 'rake'
 gem 'bcrypt'
+gem 'msgpack', '~> 1.2'
 
 platforms :mri, :rbx do
-  gem 'msgpack', '~> 1.0'
   gem 'openssl'
 end
 
 platforms :jruby do
-  gem 'msgpack-jruby', require: 'msgpack'
-  gem 'jruby-openssl'
+  gem 'jruby-openssl', '~> 0.10', require: 'openssl'
 end
 
 gemspec

--- a/lib/aerospike/socket/ssl.rb
+++ b/lib/aerospike/socket/ssl.rb
@@ -17,6 +17,8 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
+require 'openssl'
+
 module Aerospike
   module Socket
     class SSL < ::OpenSSL::SSL::SSLSocket

--- a/spec/aerospike/client_spec.rb
+++ b/spec/aerospike/client_spec.rb
@@ -224,7 +224,7 @@ describe Aerospike::Client do
         key = Support.gen_random_key
         value = {
           "string" => nil,
-          rand(2**63) => {2 => 11},
+          rand(2**31) => {2 => 11},
           [1, nil, 'this'] => {nil => "nihilism"},
           nil => ["embedded array", 1984, nil, {2 => 'string'}],
           {11 => [11, 'str']} => nil,
@@ -233,7 +233,7 @@ describe Aerospike::Client do
         bin = Aerospike::Bin.new('bin', value)
         client.put(key, bin)
         record = client.get(key)
-        expect(record.bins['bin']).to eq value
+        expect(record.bins['bin']).to eql value
       end
 
       it "should convert symbols to strings in MAP bin values" do

--- a/spec/aerospike/socket/ssl_spec.rb
+++ b/spec/aerospike/socket/ssl_spec.rb
@@ -23,7 +23,7 @@ def resource(*path)
   RESOURCE_PATH.join(*path).to_s
 end
 
-describe Aerospike::Socket::SSL do
+describe Aerospike::Socket::SSL, skip: !Support.tls_supported? do
   let(:tls_options) { {} }
 
   describe '::build_ssl_context' do

--- a/spec/support/utils.rb
+++ b/spec/support/utils.rb
@@ -85,4 +85,10 @@ EOF
     self.version >= version
   end
 
+  def self.tls_supported?
+    # Skip TLS specs on JRuby until this issue is resolved:
+    # https://github.com/jruby/jruby-openssl/issues/172
+    RUBY_PLATFORM != "java"
+  end
+
 end


### PR DESCRIPTION
* Add JRuby back to CI test matrix
* Remove dependency on `msgpack-jruby` gem which has been merged into `msgpack` gem
* TLS-encrypted connections not supported on JRuby for now, due to jruby/jruby-openssl#172