### PR TITLE
Fix setting of default policies

### DIFF
--- a/lib/aerospike/policy/client_policy.rb
+++ b/lib/aerospike/policy/client_policy.rb
@@ -26,6 +26,7 @@ module Aerospike
     attr_accessor :timeout, :connection_queue_size, :fail_if_not_connected, :tend_interval
     attr_accessor :cluster_name
     attr_accessor :tls
+    attr_accessor :policies
 
     def initialize(opt={})
       # Initial host connection timeout in seconds. The timeout when opening a connection
@@ -52,6 +53,9 @@ module Aerospike
       @cluster_name = opt[:cluster_name]
 
       @tls = opt[:tls] || opt[:ssl_options]
+
+      # Default Policies
+      @policies = opt.fetch(:policies) { Hash.new }
     end
 
     def requires_authentication

--- a/spec/aerospike/policy/client_policy_spec.rb
+++ b/spec/aerospike/policy/client_policy_spec.rb
@@ -32,6 +32,7 @@ describe Aerospike::ClientPolicy do
       expect(policy.fail_if_not_connected).to eq true
       expect(policy.user).to be_nil
       expect(policy.password).to be_nil
+      expect(policy.policies).to eql({})
     end
 
     it "should make a client policy with fail_if_not_connected set to false" do


### PR DESCRIPTION
* If no policy is set explicity for a client command,
  Client#create_policy falls back to use default_*_policy policies
  instead of creating a new policy instance.
* Add ClientPolicy#policies property to set default policies via the
  Client constructor.
* Split Client#default_policy into Client#default_read_policy and
  Client#default_info_policy.

Resolves #74