### PR TITLE
development tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ TODO
 .ruby-version
 *.gem
 .vscode
+vendor/bundle
+.bundle

--- a/spec/aerospike/batch_spec.rb
+++ b/spec/aerospike/batch_spec.rb
@@ -15,7 +15,6 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-require "spec_helper"
 require 'aerospike'
 
 describe Aerospike::Client do

--- a/spec/aerospike/bin_spec.rb
+++ b/spec/aerospike/bin_spec.rb
@@ -14,8 +14,6 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-require "spec_helper"
-
 require 'aerospike/value/value'
 
 describe Aerospike::Bin do

--- a/spec/aerospike/cdt_list_spec.rb
+++ b/spec/aerospike/cdt_list_spec.rb
@@ -14,7 +14,6 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-require "spec_helper"
 include Aerospike::CDT
 
 describe "client.operate() - CDT List Operations", skip: !Support.feature?(Aerospike::Features::CDT_LIST) do

--- a/spec/aerospike/cdt_map_spec.rb
+++ b/spec/aerospike/cdt_map_spec.rb
@@ -14,8 +14,6 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-require "spec_helper"
-
 include Aerospike
 include Aerospike::CDT
 

--- a/spec/aerospike/client_spec.rb
+++ b/spec/aerospike/client_spec.rb
@@ -15,7 +15,6 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-require "spec_helper"
 require 'aerospike'
 require 'benchmark'
 

--- a/spec/aerospike/geo_json_spec.rb
+++ b/spec/aerospike/geo_json_spec.rb
@@ -14,7 +14,6 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-require "spec_helper"
 require "aerospike/query/statement"
 
 describe Aerospike::GeoJSON do

--- a/spec/aerospike/index_spec.rb
+++ b/spec/aerospike/index_spec.rb
@@ -17,8 +17,6 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-require "spec_helper"
-
 require 'aerospike/host'
 require 'aerospike/key'
 require 'aerospike/bin'

--- a/spec/aerospike/info_spec.rb
+++ b/spec/aerospike/info_spec.rb
@@ -17,7 +17,6 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-require "spec_helper"
 require "benchmark"
 
 describe Aerospike::Info do

--- a/spec/aerospike/key_spec.rb
+++ b/spec/aerospike/key_spec.rb
@@ -14,8 +14,6 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-require "spec_helper"
-
 describe Aerospike::Key do
 
   describe "#initialize" do

--- a/spec/aerospike/policy/client_policy_spec.rb
+++ b/spec/aerospike/policy/client_policy_spec.rb
@@ -14,8 +14,6 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-require "spec_helper"
-
 require "aerospike/policy/client_policy"
 
 describe Aerospike::ClientPolicy do

--- a/spec/aerospike/policy/policy_spec.rb
+++ b/spec/aerospike/policy/policy_spec.rb
@@ -14,8 +14,6 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-require "spec_helper"
-
 require "aerospike/policy/priority"
 
 describe Aerospike::Policy do

--- a/spec/aerospike/policy/write_policy_spec.rb
+++ b/spec/aerospike/policy/write_policy_spec.rb
@@ -14,8 +14,6 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-require "spec_helper"
-
 require "aerospike/policy/priority"
 require "aerospike/policy/generation_policy"
 require "aerospike/policy/record_exists_action"

--- a/spec/aerospike/query_spec.rb
+++ b/spec/aerospike/query_spec.rb
@@ -14,7 +14,6 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-require "spec_helper"
 require "aerospike/query/statement"
 
 describe Aerospike::Client do

--- a/spec/aerospike/record_spec.rb
+++ b/spec/aerospike/record_spec.rb
@@ -14,8 +14,6 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-require "spec_helper"
-
 module Aerospike
   describe Record do
 

--- a/spec/aerospike/scan_spec.rb
+++ b/spec/aerospike/scan_spec.rb
@@ -14,7 +14,6 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-require "spec_helper"
 # require 'profile'
 
 describe Aerospike::Client do

--- a/spec/aerospike/security_spec.rb
+++ b/spec/aerospike/security_spec.rb
@@ -14,7 +14,6 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-require "spec_helper"
 require "aerospike/query/statement"
 
 describe Aerospike::Client do

--- a/spec/aerospike/udf_spec.rb
+++ b/spec/aerospike/udf_spec.rb
@@ -14,8 +14,6 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-require "spec_helper"
-
 require 'aerospike/host'
 require 'aerospike/key'
 require 'aerospike/bin'

--- a/spec/aerospike/value_spec.rb
+++ b/spec/aerospike/value_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 RSpec.describe Aerospike::Value do
   describe '::of' do
     subject(:of) { described_class.of(value) }


### PR DESCRIPTION
This PR:
- ignores bundler dependencies (installing gems to `vendor/bundle` is a common practice),
- removes `require 'spec_helper` statement, since`spec_helper` already included in `.rspec` file.
