### PR TITLE
Update Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,19 +8,18 @@ rvm:
 - 2.3
 - rbx-3
 - jruby
-env:
-  global:
-    - AEROSPIKE_HOSTS=127.0.0.1:3000,127.0.0.1:3100
-    - CODECOV_ENABLED=true
-sudo: false
-os:
-- linux
-dist: trusty
 matrix:
   allow_failures:
   - rvm: rbx-3
   - rvm: jruby
   fast_finish: true
+env:
+  global:
+    - AEROSPIKE_HOSTS=127.0.0.1:3000,127.0.0.1:3100
+    - CODECOV_ENABLED=true
+sudo: false
+os: linux
+dist: xenial
 before_script:
 - .travis/start_cluster.sh 2
 install:

--- a/.travis/aerospike.conf
+++ b/.travis/aerospike.conf
@@ -7,8 +7,6 @@ service {
   run-as-daemon
   paxos-single-replica-limit 1 # Number of nodes where the replica count is automatically reduced to 1.
   pidfile ${home}/var/run/aerospike.pid
-  transaction-queues 8
-  transaction-threads-per-queue 8
   proto-fd-max 10000
   work-directory ${home}/var
   cluster-name testCluster


### PR DESCRIPTION
* Switch from Ubuntu Trusty (14.04) to Ubuntu Xenial (16.04) image.
* Update Aerospike server config to remove deprecated settings.