### PR TITLE
Misc fixes for various broken tests

### DIFF
--- a/lib/aerospike/command/command.rb
+++ b/lib/aerospike/command/command.rb
@@ -205,18 +205,21 @@ module Aerospike
       operations.each do |operation|
         case operation.op_type
         when Aerospike::Operation::READ
-            read_attr |= INFO1_READ
+          read_attr |= INFO1_READ
 
           # Read all bins if no bin is specified.
           read_attr |= INFO1_GET_ALL unless operation.bin_name
 
         when Aerospike::Operation::READ_HEADER
-            # The server does not currently return record header data with _INFO1_NOBINDATA attribute set.
-            # The workaround is to request a non-existent bin.
-            # TODO: Fix this on server.
-            # read_attr |= _INFO1_READ | _INFO1_NOBINDATA
-            read_attr |= INFO1_READ
+          # The server does not currently return record header data with _INFO1_NOBINDATA attribute set.
+          # The workaround is to request a non-existent bin.
+          # TODO: Fix this on server.
+          # read_attr |= _INFO1_READ | _INFO1_NOBINDATA
+          read_attr |= INFO1_READ
           read_header = true
+
+        when Aerospike::Operation::CDT_READ
+          read_attr |= INFO1_READ
 
         else
           write_attr = INFO2_WRITE

--- a/lib/aerospike/result_code.rb
+++ b/lib/aerospike/result_code.rb
@@ -116,6 +116,9 @@ module Aerospike
     # Enterprise-only feature not supported by the community edition
     ENTERPRISE_ONLY = 25
 
+    # The operation cannot be applied to the current bin value on the server.
+    OP_NOT_APPLICABLE = 26
+
     # There are no more records left for query.
     QUERY_END = 50
 
@@ -294,6 +297,9 @@ module Aerospike
 
       when ENTERPRISE_ONLY
         "Enterprise-only feature not supported by community edition"
+
+      when OP_NOT_APPLICABLE
+        "The operation cannot be applied to the current bin value on the server."
 
       when QUERY_END
         "Query end"

--- a/lib/aerospike/value/value.rb
+++ b/lib/aerospike/value/value.rb
@@ -137,7 +137,7 @@ module Aerospike
     end
   end
 
-  INFINITY = InfinityValue.new.freeze
+  INFINITY = Value::INFINITY = InfinityValue.new.freeze
 
   # Wildcard value.
   class WildcardValue < Value #:nodoc:
@@ -178,7 +178,7 @@ module Aerospike
     end
   end
 
-  WILDCARD = WildcardValue.new.freeze
+  WILDCARD = Value::WILDCARD = WildcardValue.new.freeze
 
   # Byte array value.
   class BytesValue < Value #:nodoc:

--- a/spec/aerospike/cdt_list_spec.rb
+++ b/spec/aerospike/cdt_list_spec.rb
@@ -268,7 +268,7 @@ describe "client.operate() - CDT List Operations", skip: !Support.feature?(Aeros
       operation = ListOperation.get_by_index(list_bin, 2)
       result = client.operate(key, [operation])
 
-      expect(result.bins[list_bin]).to be nil
+      expect(result.bins).to be nil
     end
 
     it "returns the value at the specified index" do
@@ -704,7 +704,7 @@ describe "client.operate() - CDT List Operations", skip: !Support.feature?(Aeros
     let(:list_value) { [0, 4, 5, 9, 11, 15] }
 
     it "returns all list elements from 10 to Infinity" do
-      operation = ListOperation.get_by_value_range(list_bin, 10, Value::INFINITY)
+      operation = ListOperation.get_by_value_range(list_bin, 10, Aerospike::Value::INFINITY)
         .and_return(return_type)
 
       result = client.operate(key, [operation])
@@ -717,7 +717,7 @@ describe "client.operate() - CDT List Operations", skip: !Support.feature?(Aeros
     let(:list_value) { [ ["John", 55], ["Jim", 95], ["Joe", 80], ["Jim", 46] ] }
 
     it "returns all list elements that match a wildcard" do
-      operation = ListOperation.get_by_value(list_bin, ["Jim", Value::WILDCARD])
+      operation = ListOperation.get_by_value(list_bin, ["Jim", Aerospike::Value::WILDCARD])
         .and_return(return_type)
 
       result = client.operate(key, [operation])

--- a/spec/aerospike/cdt_list_spec.rb
+++ b/spec/aerospike/cdt_list_spec.rb
@@ -15,6 +15,7 @@
 # the License.
 
 include Aerospike::CDT
+include Aerospike::ResultCode
 
 describe "client.operate() - CDT List Operations", skip: !Support.feature?(Aerospike::Features::CDT_LIST) do
 
@@ -238,7 +239,7 @@ describe "client.operate() - CDT List Operations", skip: !Support.feature?(Aeros
     it "returns an error if the index is out of bounds" do
       operation = ListOperation.get(list_bin, 99)
 
-      expect { client.operate(key, [operation]) }.to raise_error(/Parameter error/)
+      expect { client.operate(key, [operation]) }.to raise_aerospike_error(OP_NOT_APPLICABLE)
     end
   end
 
@@ -281,7 +282,7 @@ describe "client.operate() - CDT List Operations", skip: !Support.feature?(Aeros
     it "returns an error if the index is out of bounds" do
       operation = ListOperation.get_by_index(list_bin, 99)
 
-      expect { client.operate(key, [operation]) }.to raise_error(/Parameter error/)
+      expect { client.operate(key, [operation]) }.to raise_aerospike_error(OP_NOT_APPLICABLE)
     end
   end
 
@@ -419,7 +420,7 @@ describe "client.operate() - CDT List Operations", skip: !Support.feature?(Aeros
     it "returns an error if the index is out of bounds" do
       operation = ListOperation.remove_by_index(list_bin, 99)
 
-      expect { client.operate(key, [operation]) }.to raise_error(/Parameter error/)
+      expect { client.operate(key, [operation]) }.to raise_aerospike_error(OP_NOT_APPLICABLE)
     end
   end
 
@@ -694,7 +695,7 @@ describe "client.operate() - CDT List Operations", skip: !Support.feature?(Aeros
       it "throws an error when trying to insert an item outside the existing list boundaries", skip: !Support.min_version?("4.3") do
         operation = ListOperation.insert(list_bin, 99, 6, policy: list_policy)
 
-        expect { client.operate(key, [operation]) }.to raise_error(/Parameter error/)
+        expect { client.operate(key, [operation]) }.to raise_aerospike_error(OP_NOT_APPLICABLE)
       end
     end
   end

--- a/spec/aerospike/cdt_map_spec.rb
+++ b/spec/aerospike/cdt_map_spec.rb
@@ -596,7 +596,7 @@ describe "client.operate() - CDT Map Operations", skip: !Support.feature?(Aerosp
           .and_return(MapReturnType::NONE)
         result = client.operate(key, [operation])
 
-        expect(result.bins[map_bin]).to eql(nil)
+        expect(result.bins).to eql(nil)
       end
     end
 
@@ -941,7 +941,7 @@ describe "client.operate() - CDT Map Operations", skip: !Support.feature?(Aerosp
     let(:map_value) { { 0 => 17, 4 => 2, 5 => 15, 9 => 10 } }
 
     it "returns all keys from 5 to Infinity" do
-      operation = MapOperation.get_by_key_range(map_bin, 5, Value::INFINITY)
+      operation = MapOperation.get_by_key_range(map_bin, 5, Aerospike::Value::INFINITY)
         .and_return(MapReturnType::KEY)
 
       result = client.operate(key, [operation])
@@ -959,7 +959,7 @@ describe "client.operate() - CDT Map Operations", skip: !Support.feature?(Aerosp
     } }
 
     it "returns all values that match a wildcard" do
-      operation = MapOperation.get_by_value(map_bin, ["Jim", Value::WILDCARD])
+      operation = MapOperation.get_by_value(map_bin, ["Jim", Aerospike::Value::WILDCARD])
         .and_return(MapReturnType::KEY)
 
       result = client.operate(key, [operation])

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,7 @@
 
 require 'rspec'
 require 'support/utils'
+require 'support/matchers'
 
 require 'simplecov'
 SimpleCov.start

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -1,0 +1,13 @@
+require 'rspec/expectations'
+
+puts 'defining raise_aerospike_error'
+
+module RSpec
+  module Matchers
+    def raise_aerospike_error(expected_result_code)
+      raise_error(Aerospike::Exceptions::Aerospike) { |error|
+        expect(error.result_code).to eq expected_result_code
+      }
+    end
+  end
+end


### PR DESCRIPTION
Fix a couple of tests that were broken due to minor changes in server behaviour:
* CDT read ops now require INFO1_READ flag.
* Some CDT ops now return a new "op not applicable" result code instead of a generic parameter error.
* Behaviour for some CDT ops with return type NONE has changed.
* Fix usage of INFINITY & WILDCARD values - not sure how this ever worked in the past...