### PR TITLE
fix read_users to avoid error

### DIFF
--- a/lib/aerospike/command/admin_command.rb
+++ b/lib/aerospike/command/admin_command.rb
@@ -381,7 +381,7 @@ module Aerospike
         raise e
       end
 
-      raise Exceptions::Aerospike.new(result) if status > 0
+      raise Exceptions::Aerospike.new(status) if status > 0
 
       return list
     end


### PR DESCRIPTION
fix error:
Traceback (most recent call last):
        9: from /Users/dotanmor/.rvm/gems/ruby-2.6.6/bin/ruby_executable_hooks:22:in `<main>'
        8: from /Users/dotanmor/.rvm/gems/ruby-2.6.6/bin/ruby_executable_hooks:22:in `eval'
        7: from /Users/dotanmor/.rvm/gems/ruby-2.6.6/bin/irb:23:in `<main>'
        6: from /Users/dotanmor/.rvm/gems/ruby-2.6.6/bin/irb:23:in `load'
        5: from /Users/dotanmor/.rvm/gems/ruby-2.6.6/gems/irb-1.2.7/exe/irb:11:in `<top (required)>'
        4: from (irb):30
        3: from /Users/dotanmor/.rvm/gems/ruby-2.6.6/gems/aerospike-2.21.1/lib/aerospike/client.rb:816:in `query_user'
        2: from /Users/dotanmor/.rvm/gems/ruby-2.6.6/gems/aerospike-2.21.1/lib/aerospike/command/admin_command.rb:180:in `query_user'
        1: from /Users/dotanmor/.rvm/gems/ruby-2.6.6/gems/aerospike-2.21.1/lib/aerospike/command/admin_command.rb:386:in `read_users'
NameError (undefined local variable or method `result' for #<Aerospike::AdminCommand:0x00007fd308446780>)