### PR TITLE
Update github workflow

### DIFF
--- a/.github/workflows/aerospike.conf
+++ b/.github/workflows/aerospike.conf
@@ -5,7 +5,6 @@ service {
   user ${user}
   group ${group}
   run-as-daemon
-  paxos-single-replica-limit 1 # Number of nodes where the replica count is automatically reduced to 1.
   pidfile ${home}/var/run/aerospike.pid
   proto-fd-max 10000
   work-directory ${home}/var

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -6,19 +6,21 @@ jobs:
   test:
     runs-on: ${{matrix.os}}-latest
     continue-on-error: ${{matrix.experimental}}
-    
+
     strategy:
       matrix:
         os:
           - ubuntu
-        
+
         ruby:
-          - 2.6
           - 2.7
-        
+          - 3.0
+          - 3.1
+          - 3.2
+
         experimental: [false]
         env: [""]
-        
+
         include:
           - os: ubuntu
             ruby: head
@@ -30,14 +32,14 @@ jobs:
       with:
         ruby-version: ${{matrix.ruby}}
         bundler-cache: true
-    
+
     - name: Start server
       timeout-minutes: 5
       env:
         TERM: dumb
       run:
         .github/workflows/start_cluster.sh 2
-    
+
     - name: Run tests
       timeout-minutes: 30
       env:


### PR DESCRIPTION
The workflow stopped working after Aerospike released server v6.0, which removed the `paxos-single-replica-limit` parameter.