### PR TITLE
fix: BatchRead with operations

### DIFF
--- a/lib/aerospike/batch_read.rb
+++ b/lib/aerospike/batch_read.rb
@@ -88,7 +88,7 @@ module Aerospike
           raise AerospikeException.new(ResultCode::PARAMETER_ERROR, "Write operations not allowed in batch read")
         end
         size += op.bin_name.bytesize + Aerospike::OPERATION_HEADER_SIZE
-        size += op.value.estimate_size
+        size += op.bin_value.estimate_size
       end
 
       size

--- a/lib/aerospike/batch_read.rb
+++ b/lib/aerospike/batch_read.rb
@@ -68,7 +68,7 @@ module Aerospike
     # For internal use only.
     def ==(other) # :nodoc:
       other && other.instance_of?(self.class) &&
-        @bin_names.sort == other.bin_names.sort && @ops.sort == other.ops.sort &&
+        @bin_names&.sort == other.bin_names&.sort && @ops == other.ops &&
         @policy == other.policy && @read_all_bins == other.read_all_bins
     end
 

--- a/lib/aerospike/command/batch_operate_command.rb
+++ b/lib/aerospike/command/batch_operate_command.rb
@@ -92,7 +92,7 @@ module Aerospike
             if record.bin_names&.length&.> 0
               write_batch_bin_names(key, record.bin_names, attr, attr.filter_exp)
             elsif record.ops&.length&.> 0
-              attr.adjust_read(br.ops)
+              attr.adjust_read(record.ops)
               write_batch_operations(key, record.ops, attr, attr.filter_exp)
             else
               attr.adjust_read_all_bins(record.read_all_bins)

--- a/spec/aerospike/batch_operate_spec.rb
+++ b/spec/aerospike/batch_operate_spec.rb
@@ -61,6 +61,18 @@ describe Aerospike::Client do
         expect(records[0].record.bins.length).to eql 3
       end
 
+      it 'returns bins specified with operations' do
+        ops = [
+          Aerospike::Operation.get("idx"),
+          Aerospike::Operation.get("rnd")
+        ]
+        records = [Aerospike::BatchRead.ops(keys.first, ops)]
+        client.batch_operate(records, batch_policy)
+
+        expect(records[0].result_code).to eql(0)
+        expect(records[0].record.bins).to eql({ "idx"=>0, "rnd"=>99 })
+      end
+
       it 'filter out' do
         records = [Aerospike::BatchRead.read_all_bins(keys.first)]
         client.batch_operate(records, opts)

--- a/spec/aerospike/batch_operate_spec.rb
+++ b/spec/aerospike/batch_operate_spec.rb
@@ -66,11 +66,16 @@ describe Aerospike::Client do
           Aerospike::Operation.get("idx"),
           Aerospike::Operation.get("rnd")
         ]
-        records = [Aerospike::BatchRead.ops(keys.first, ops)]
+        records = [
+          Aerospike::BatchRead.ops(keys.first, ops),
+          Aerospike::BatchRead.ops(keys.last, ops)
+        ]
         client.batch_operate(records, batch_policy)
 
         expect(records[0].result_code).to eql(0)
+        expect(records[1].result_code).to eql(0)
         expect(records[0].record.bins).to eql({ "idx"=>0, "rnd"=>99 })
+        expect(records[1].record.bins).to eql({ "idx"=>2, "rnd"=>99 })
       end
 
       it 'filter out' do


### PR DESCRIPTION
This pull request:
- fixes invalid local variable reference in `BatchOperateCommand`
  ```bash
  /aerospike-client-ruby/lib/aerospike/command/batch_operate_command.rb:95:in `block in write_buffer': undefined local variable or method `br' for an instance of Aerospike::BatchOperateCommand (NameError)

              attr.adjust_read(br.ops)
                               ^^
        from /aerospike-client-ruby/lib/aerospike/command/batch_operate_command.rb:81:in `each'
        from /aerospike-client-ruby/lib/aerospike/command/batch_operate_command.rb:81:in `each_with_index'
        from /aerospike-client-ruby/lib/aerospike/command/batch_operate_command.rb:81:in `write_buffer'
        from /aerospike-client-ruby/lib/aerospike/command/command.rb:718:in `execute'
        from /aerospike-client-ruby/lib/aerospike/client.rb:973:in `execute_command'
        from /aerospike-client-ruby/lib/aerospike/client.rb:1005:in `block (2 levels) in execute_batch_operate_commands'
  ```


- fixes attribute reference in size calculation for the `BatchRead`

  ```bash
  /aerospike-client-ruby/lib/aerospike/batch_read.rb:91:in `block in size': undefined method `value' for an instance of Aerospike::Operation (NoMethodError)

        size += op.value.estimate_size
                  ^^^^^^
        from /aerospike-client-ruby/lib/aerospike/batch_read.rb:86:in `each'
        from /aerospike-client-ruby/lib/aerospike/batch_read.rb:86:in `size'
        from /aerospike-client-ruby/lib/aerospike/command/batch_operate_command.rb:63:in `block in write_buffer'
        from /aerospike-client-ruby/lib/aerospike/command/batch_operate_command.rb:53:in `each'
        from /aerospike-client-ruby/lib/aerospike/command/batch_operate_command.rb:53:in `write_buffer'
        from /aerospike-client-ruby/lib/aerospike/command/command.rb:718:in `execute'
        from /aerospike-client-ruby/lib/aerospike/client.rb:973:in `execute_command'
        from /aerospike-client-ruby/lib/aerospike/client.rb:1005:in `block (2 levels) in execute_batch_operate_commands'
  ```

- fixes `BatchRead` with multiple records using operations (2 issues)
  ```bash
  /aerospike-client-ruby/lib/aerospike/batch_read.rb:71:in `==': undefined method `sort' for nil (NoMethodError)

        @bin_names.sort == other.bin_names.sort && @ops.sort == other.ops.sort &&
                  ^^^^^
        from /aerospike-client-ruby/lib/aerospike/command/batch_operate_command.rb:57:in `block in write_buffer'
        from /aerospike-client-ruby/lib/aerospike/command/batch_operate_command.rb:53:in `each'
        from /aerospike-client-ruby/lib/aerospike/command/batch_operate_command.rb:53:in `write_buffer'
        from /aerospike-client-ruby/lib/aerospike/command/command.rb:718:in `execute'
        from /aerospike-client-ruby/lib/aerospike/client.rb:973:in `execute_command'
        from /aerospike-client-ruby/lib/aerospike/client.rb:1005:in `block (2 levels) in execute_batch_operate_commands'
  ```
  ```bash
  /aerospike-client-ruby/lib/aerospike/batch_read.rb:71:in `sort': comparison of Aerospike::Operation with Aerospike::Operation failed (ArgumentError)
        from /aerospike-client-ruby/lib/aerospike/batch_read.rb:71:in `=='
        from /aerospike-client-ruby/lib/aerospike/command/batch_operate_command.rb:57:in `block in write_buffer'
        from /aerospike-client-ruby/lib/aerospike/command/batch_operate_command.rb:53:in `each'
        from /aerospike-client-ruby/lib/aerospike/command/batch_operate_command.rb:53:in `write_buffer'
        from /aerospike-client-ruby/lib/aerospike/command/command.rb:718:in `execute'
        from /aerospike-client-ruby/lib/aerospike/client.rb:973:in `execute_command'
        from /aerospike-client-ruby/lib/aerospike/client.rb:1005:in `block (2 levels) in execute_batch_operate_commands'
  ```