### PR TITLE
Remove deprecated third argument to BCrypt::Engine.hash_secret

### DIFF
--- a/lib/aerospike/command/login_command.rb
+++ b/lib/aerospike/command/login_command.rb
@@ -156,8 +156,10 @@ module Aerospike
 
     SALT = '$2a$10$7EqJtq98hPqEX7fNZaFWoO'
     def self.hash_password(password)
-      # Hashing the password with the cost of 10, with a static salt
-      return BCrypt::Engine.hash_secret(password, SALT, :cost => 10)
+      # Hashing the password with a static salt. The cost (10) is already
+      # encoded in SALT, so the third argument to hash_secret is redundant
+      # and has been removed (bcrypt >= 3.1.19 deprecates passing it).
+      return BCrypt::Engine.hash_secret(password, SALT)
     end
   end
 end


### PR DESCRIPTION
Fixes #140.

### Problem

`LoginCommand.hash_password` calls:

```ruby
BCrypt::Engine.hash_secret(password, SALT, :cost => 10)
```

Since bcrypt `3.1.19`, passing a third argument to `hash_secret` emits:

```
[DEPRECATION] Passing the third argument to `BCrypt::Engine.hash_secret` is deprecated. Please do not pass the third argument which is currently not used.
```

The warning fires on every client/cluster initialization (see the stack trace in #140).

### Fix

The cost factor is already encoded in the static `SALT` (`$2a$10$...` → cost 10), so the explicit `:cost => 10` argument is redundant and ignored by bcrypt. This PR removes it.

### Verification

The produced hash is byte-for-byte identical with and without the argument:

```ruby
SALT = "$2a$10$7EqJtq98hPqEX7fNZaFWoO"
BCrypt::Engine.hash_secret("pw", SALT, :cost => 10) == BCrypt::Engine.hash_secret("pw", SALT)
# => true
```

So authentication behavior is unchanged; only the deprecation warning is silenced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)